### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills using GitHub, part of the GitHub Certifications program",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 30,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary

Adds the **GitHub Skills** activity to the school activities signup page, addressing Issue #6.

## Changes

- Added "GitHub Skills" to the activities dictionary in `src/app.py`
  - **Description:** Learn practical coding and collaboration skills using GitHub, part of the GitHub Certifications program
  - **Schedule:** Mondays and Wednesdays, 3:30 PM - 4:30 PM
  - **Max participants:** 30
  - **Participants:** Empty (ready for signups)

## Why

The principal announced a new partnership with GitHub to teach students practical coding and collaboration skills. Students need to register before the end of this week, and this activity was missing from the signup page.

Closes #6